### PR TITLE
fix: NrIntegrationErrors due to metric name and attribute name issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 cmd/standalone/standalone
 cmd/standalone/*.yaml
 cmd/playground
+config.yaml
+*.local.*
+main


### PR DESCRIPTION
## Fixes
* `NrIntegrationError` messages due to reserved words being used in attribute names (`appId` and `appName`)
* `NrIntegrationError` messages due to some attribute names being the same as metrics names