### PR TITLE
fix!: remove 386 from goreleaser config, doc updates, and bump major version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,6 @@ builds:
       - linux
       - windows
     goarch:
-      - "386"
       - amd64
     ldflags:
       - '-s -w -X main.gInterationVersion={{.Version}} -X main.gGitCommit={{.Commit}} -X main.gBuildDate={{.Date}}'

--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ To get started with the New Relic Databricks integration, [deploy the integratio
 The New Relic Databricks integration provides binaries for the following
 host platforms.
 
-* Linux x86
 * Linux amd64
-* Windows x86
 * Windows amd64
 
 #### Deploy the integration on host
@@ -325,6 +323,106 @@ executors (`app.executor.memoryUsed`) will be `spark.app.executor.memoryUsed`.
 
 **NOTE:** It is not recommended to leave this value empty as the metric names
 without a prefix may be ambiguous.
+
+## Building
+
+### Coding Conventions
+
+#### Style Guidelines
+
+While not strictly enforced, the basic preferred editor settings are set in the
+[.editorconfig](./.editorconfig). Other than this, no style guidelines are
+currently imposed.
+
+#### Static Analysis
+
+This project uses both [`go vet`](https://pkg.go.dev/cmd/vet) and
+[`staticcheck`](https://staticcheck.io/) to perform static code analysis. These
+checks are run via [`precommit`](https://pre-commit.com) on all commits. Though
+this can be bypassed on local commit, both tasks are also run during
+[the `validate` workflow](./.github/workflows/validate.yml) and must have no
+errors in order to be merged.
+
+#### Commit Messages
+
+Commit messages must follow [the conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).
+Again, while this can be bypassed on local commit, it is strictly enforced in
+[the `validate` workflow](./.github/workflows/validate.yml).
+
+The basic commit message structure is as follows.
+
+```
+<type>[optional scope][!]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+In addition to providing consistency, the commit message is used by
+[svu](https://github.com/caarlos0/svu) during
+[the release workflow](./.github/workflows/release.yml). The presence and values
+of certain elements within the commit message affect auto-versioning. For
+example, the `feat` type will bump the minor version. Therefore, it is important
+to use the guidelines below and carefully consider the content of the commit
+message.
+
+Please use one of the types below.
+
+- `feat` (bumps minor version)
+- `fix` (bumps patch version)
+- `chore`
+- `build`
+- `docs`
+- `test`
+
+Any type can be followed by the `!` character to indicate a breaking change.
+Additionally, any commit that has the text `BREAKING CHANGE:` in the footer will
+indicate a breaking change.
+
+### Local Development
+
+For local development, simply use `go build` and `go run`. For example,
+
+```bash
+go build cmd/databricks/databricks.go
+```
+
+Or
+
+```bash
+go run cmd/databricks/databricks.go
+```
+
+If you prefer, you can also use [`goreleaser`](https://goreleaser.com/) with
+the `--single-target` option to build the binary for the local `GOOS` and
+`GOARCH` only.
+
+```bash
+goreleaser build --single-target
+```
+
+### Releases
+
+Releases are built and packaged using [`goreleaser`](https://goreleaser.com/).
+By default, a new release will be built automatically on any push to the `main`
+branch. For more details, review the [`.goreleaser.yaml`](./.goreleaser.yaml)
+and [the `goreleaser` documentation](https://goreleaser.com/intro/).
+
+The [svu](https://github.com/caarlos0/svu) utility is used to generate the next
+tag value [based on commit messages](https://github.com/caarlos0/svu#commit-messages-vs-what-they-do).
+
+### GitHub Workflows
+
+This project utilizes GitHub workflows to perform actions in response to
+certain GitHub events.
+
+| Workflow | Events | Description
+| --- | --- | --- |
+| [validate](./.github/workflows/validate.yml) | `push`, `pull_request` to `main` branch | Runs [precommit](https://pre-commit.com) to perform static analysis and runs [commitlint](https://commitlint.js.org/#/) to validate the last commit message |
+| [build](./.github/workflows/build.yml) | `push`, `pull_request` | Builds and tests code |
+| [release](./.github/workflows/release.yml) | `push` to `main` branch | Generates a new tag using [svu](https://github.com/caarlos0/svu) and runs [`goreleaser`](https://goreleaser.com/) |
+| [repolinter](./.github/workflows/repolinter.yml) | `pull_request` | Enforces repository content guidelines |
 
 ## Support
 


### PR DESCRIPTION
# Description

* Remove `386` targets from goreleaser because databricks-sdk does not support it
* Add build details to docs
* Use `fix!` to bump major version to 2.0.0

## Type of change

- [X] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
