### PR TITLE
feat: leverage databricks sdk for authentication by using sdk for all api calls, include Spark

### DIFF
--- a/configs/config.template.yml
+++ b/configs/config.template.yml
@@ -15,8 +15,10 @@ log:
 mode: databricks
 
 databricks:
-  accessToken: [YOUR_DATABRICKS_ACCESS_TOKEN]
   workspaceHost: [YOUR_DATABRICKS_WORKSPACE_INSTANCE_NAME]
+  accessToken: [YOUR_DATABRICKS_PERSONAL_ACCESS_TOKEN]
+  oauthClientId: [YOUR_DATABRICKS_SERVICE_PRINCIPAL_OAUTH_CLIENT_ID]
+  oauthClientSecret: [YOUR_DATABRICKS_SERVICE_PRINCIPAL_OAUTH_CLIENT_SECRET]
   # RESERVED FOR FUTURE USE
   #accountHost: https://accounts.cloud.databricks.com
   # RESERVED FOR FUTURE USE

--- a/internal/databricks/client.go
+++ b/internal/databricks/client.go
@@ -1,0 +1,141 @@
+package databricks
+
+import (
+	"context"
+	"net/http"
+
+	databricksSdk "github.com/databricks/databricks-sdk-go"
+	databricksSdkClient "github.com/databricks/databricks-sdk-go/client"
+	"github.com/newrelic-experimental/newrelic-databricks-integration/internal/spark"
+)
+
+type DatabricksSparkApiClient struct {
+	sparkContextUiPath		string
+	client					*databricksSdkClient.DatabricksClient
+}
+
+func NewDatabricksSparkApiClient(
+	sparkContextUiPath string,
+	w *databricksSdk.WorkspaceClient,
+) (*DatabricksSparkApiClient, error) {
+	cfg := w.Config
+
+	// The following 10 lines are taken from the WorkspaceClient code at
+	// https://github.com/databricks/databricks-sdk-go/blob/main/workspace_client.go#L1100
+	// We do it ourselves here since we don't have access to either the
+	// apiClient or databricksClient on the WorkspaceClient.
+
+	apiClient, err := cfg.NewApiClient()
+	if err != nil {
+		return nil, err
+	}
+
+	databricksClient, err := databricksSdkClient.NewWithClient(cfg, apiClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DatabricksSparkApiClient{
+		sparkContextUiPath,
+		databricksClient,
+	}, nil
+}
+
+func (s *DatabricksSparkApiClient) GetApplications(
+	ctx context.Context,
+) ([]spark.SparkApplication, error) {
+	sparkApps := []spark.SparkApplication{}
+
+	// Here and throughout we follow the pattern at
+	// https://github.com/databricks/databricks-sdk-go/blob/main/service/apps/impl.go#L18
+	// using our own DatabricksClient. Again, because we don't have access to
+	// the databricksClient on the WorkspaceClient
+
+	path := s.sparkContextUiPath + "/api/v1/applications"
+	headers := make(map[string]string)
+	headers["Accept"] = "application/json"
+	headers["Content-Type"] = "application/json"
+
+	err := s.client.Do(ctx, http.MethodGet, path, headers, nil, &sparkApps)
+	if err != nil {
+		return nil, err
+	}
+
+	return sparkApps, nil
+}
+
+func (s *DatabricksSparkApiClient) GetApplicationExecutors(
+	ctx context.Context,
+	app *spark.SparkApplication,
+) ([]spark.SparkExecutor, error) {
+	executors := []spark.SparkExecutor{}
+
+	path := s.sparkContextUiPath + "/api/v1/applications/" + app.Id + "/executors"
+	headers := make(map[string]string)
+	headers["Accept"] = "application/json"
+	headers["Content-Type"] = "application/json"
+
+	err := s.client.Do(ctx, http.MethodGet, path, headers, nil, &executors)
+	if err != nil {
+		return nil, err
+	}
+
+	return executors, nil
+}
+
+func (s *DatabricksSparkApiClient) GetApplicationJobs(
+	ctx context.Context,
+	app *spark.SparkApplication,
+) ([]spark.SparkJob, error) {
+	jobs := []spark.SparkJob{}
+
+	path := s.sparkContextUiPath + "/api/v1/applications/" + app.Id + "/jobs"
+	headers := make(map[string]string)
+	headers["Accept"] = "application/json"
+	headers["Content-Type"] = "application/json"
+
+	err := s.client.Do(ctx, http.MethodGet, path, headers, nil, &jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	return jobs, nil
+}
+
+func (s *DatabricksSparkApiClient) GetApplicationStages(
+	ctx context.Context,
+	app *spark.SparkApplication,
+) ([]spark.SparkStage, error) {
+	stages := []spark.SparkStage{}
+
+	path := s.sparkContextUiPath + "/api/v1/applications/" + app.Id + "/stages?details=true"
+	headers := make(map[string]string)
+	headers["Accept"] = "application/json"
+	headers["Content-Type"] = "application/json"
+
+	err := s.client.Do(ctx, http.MethodGet, path, headers, nil, &stages)
+	if err != nil {
+		return nil, err
+	}
+
+	return stages, nil
+}
+
+func (s *DatabricksSparkApiClient) GetApplicationRDDs(
+	ctx context.Context,
+	app *spark.SparkApplication,
+) ([]spark.SparkRDD, error) {
+	rdds := []spark.SparkRDD{}
+
+	path := s.sparkContextUiPath + "/api/v1/applications/" + app.Id + "/storage/rdd"
+	headers := make(map[string]string)
+	headers["Accept"] = "application/json"
+	headers["Content-Type"] = "application/json"
+
+	err := s.client.Do(ctx, http.MethodGet, path, headers, nil, &rdds)
+	if err != nil {
+		return nil, err
+	}
+
+	return rdds, nil
+}

--- a/internal/spark/client.go
+++ b/internal/spark/client.go
@@ -1,0 +1,170 @@
+package spark
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/connectors"
+	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/log"
+)
+
+type SparkApiClient interface {
+	GetApplications(ctx context.Context) ([]SparkApplication, error)
+	GetApplicationExecutors(
+		ctx context.Context,
+		app *SparkApplication,
+	) ([]SparkExecutor, error)
+	GetApplicationJobs(
+		ctx context.Context,
+		app *SparkApplication,
+	) ([]SparkJob, error)
+	GetApplicationStages(
+		ctx context.Context,
+		app *SparkApplication,
+	) ([]SparkStage, error)
+	GetApplicationRDDs(
+		ctx context.Context,
+		app *SparkApplication,
+	) ([]SparkRDD, error)
+}
+
+type NativeSparkApiClient struct {
+	sparkContextUiUrl		string
+	authenticator			connectors.HttpAuthenticator
+}
+
+func NewNativeSparkApiClient(
+	sparkContextUiUrl string,
+	authenticator connectors.HttpAuthenticator,
+) *NativeSparkApiClient {
+	return &NativeSparkApiClient{
+		sparkContextUiUrl,
+		authenticator,
+	}
+}
+
+func (s *NativeSparkApiClient) GetApplications(
+	ctx context.Context,
+) ([]SparkApplication, error) {
+	sparkApps := []SparkApplication{}
+
+	err := makeRequest(
+		s.sparkContextUiUrl + "/api/v1/applications",
+		s.authenticator,
+		&sparkApps,
+	)
+	if err !=  nil {
+		return nil, err
+	}
+
+	return sparkApps, nil
+}
+
+func (s *NativeSparkApiClient) GetApplicationExecutors(
+	ctx context.Context,
+	app *SparkApplication,
+) ([]SparkExecutor, error) {
+	executors := []SparkExecutor{}
+
+	err := makeRequest(
+		s.sparkContextUiUrl + "/api/v1/applications/" + app.Id + "/executors",
+		s.authenticator,
+		&executors,
+	)
+	if err !=  nil {
+		return nil, err
+	}
+
+	return executors, nil
+}
+
+func (s *NativeSparkApiClient) GetApplicationJobs(
+	ctx context.Context,
+	app *SparkApplication,
+) ([]SparkJob, error) {
+	jobs := []SparkJob{}
+
+	err := makeRequest(
+		s.sparkContextUiUrl + "/api/v1/applications/" + app.Id + "/jobs",
+		s.authenticator,
+		&jobs,
+	)
+	if err !=  nil {
+		return nil, err
+	}
+
+	return jobs, nil
+}
+
+func (s *NativeSparkApiClient) GetApplicationStages(
+	ctx context.Context,
+	app *SparkApplication,
+) ([]SparkStage, error) {
+	stages := []SparkStage{}
+
+	err := makeRequest(
+		s.sparkContextUiUrl + "/api/v1/applications/" + app.Id + "/stages?details=true",
+		s.authenticator,
+		&stages,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return stages, nil
+}
+
+func (s *NativeSparkApiClient) GetApplicationRDDs(
+	ctx context.Context,
+	app *SparkApplication,
+) ([]SparkRDD, error) {
+	rdds := []SparkRDD{}
+
+	err := makeRequest(
+		s.sparkContextUiUrl + "/api/v1/applications/" + app.Id + "/storage/rdd",
+		s.authenticator,
+		&rdds,
+	)
+	if err !=  nil {
+		return nil, err
+	}
+
+	return rdds, nil
+}
+
+func makeRequest(
+	url string,
+	authenticator connectors.HttpAuthenticator,
+	response interface{},
+) error {
+	connector := connectors.NewHttpGetConnector(url)
+
+	if authenticator != nil {
+		connector.SetAuthenticator(authenticator)
+	}
+
+	connector.SetHeaders(map[string]string {
+		"Content-Type": "application/json",
+		"Accept": "application/json",
+	})
+
+	in, err := connector.Request()
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("decoding spark JSON response for URL %s", url)
+
+	dec := json.NewDecoder(in)
+
+	err = dec.Decode(response)
+	if err != nil {
+		return err
+	}
+
+	if log.IsDebugEnabled() {
+		log.PrettyPrintJson(response)
+	}
+
+	return nil
+}

--- a/internal/spark/spark.go
+++ b/internal/spark/spark.go
@@ -2,7 +2,6 @@ package spark
 
 import (
 	"github.com/newrelic/newrelic-labs-sdk/pkg/integration"
-	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/connectors"
 	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/exporters"
 	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/pipeline"
 	"github.com/spf13/viper"
@@ -299,10 +298,9 @@ func InitPipelines(i *integration.LabsIntegration) error {
 }
 */
 
-func InitPipelinesForContext(
+func InitPipelines(
 	i *integration.LabsIntegration,
-	sparkContextUiUrl string,
-	authenticator connectors.HttpAuthenticator,
+	sparkApiConnector SparkApiClient,
 	tags map[string]string,
 ) error {
 	// Create the newrelic exporter
@@ -318,8 +316,7 @@ func InitPipelinesForContext(
 	err := setupReceivers(
 		i,
 		mp,
-		sparkContextUiUrl,
-		authenticator,
+		sparkApiConnector,
 		tags,
 	)
 	if err != nil {
@@ -334,14 +331,12 @@ func InitPipelinesForContext(
 func setupReceivers(
 	i *integration.LabsIntegration,
 	mp *pipeline.MetricsPipeline,
-	sparkContextUiUrl string,
-	authenticator connectors.HttpAuthenticator,
+	client SparkApiClient,
 	tags map[string]string,
 ) error {
 	sparkReceiver := NewSparkMetricsReceiver(
 		i,
-		sparkContextUiUrl,
-		authenticator,
+		client,
 		viper.GetString("spark.metricPrefix"),
 		tags,
 	)

--- a/internal/spark/spark.go
+++ b/internal/spark/spark.go
@@ -300,7 +300,7 @@ func InitPipelines(i *integration.LabsIntegration) error {
 
 func InitPipelines(
 	i *integration.LabsIntegration,
-	sparkApiConnector SparkApiClient,
+	sparkApiClient SparkApiClient,
 	tags map[string]string,
 ) error {
 	// Create the newrelic exporter
@@ -316,7 +316,7 @@ func InitPipelines(
 	err := setupReceivers(
 		i,
 		mp,
-		sparkApiConnector,
+		sparkApiClient,
 		tags,
 	)
 	if err != nil {


### PR DESCRIPTION
# Description

Use the [Databricks SDK for Go](https://docs.databricks.com/en/dev-tools/sdk-go.html) for all API calls, including the calls to the Spark ReST API.  This allows us to delegate all authentication to the SDK.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
