### PR TITLE
fix: executor used on/off heap storage not displaying due to wrong metric names

### DIFF
--- a/examples/spark-daskboard.json
+++ b/examples/spark-daskboard.json
@@ -1030,7 +1030,7 @@
                   "accountIds": [
                     0
                   ],
-                  "query": "FROM Metric SELECT average(spark.app.executor.memory.usedOnHeapStorageMemory) WHERE sparkAppExecutorId != 'driver' AND spark.app.executor.memory.usedOnHeapStorageMemory IS NOT NULL TIMESERIES FACET sparkAppExecutorId"
+                  "query": "FROM Metric SELECT average(spark.app.executor.memory.usedOnHeapStorage) WHERE sparkAppExecutorId != 'driver' AND spark.app.executor.memory.usedOnHeapStorage IS NOT NULL TIMESERIES FACET sparkAppExecutorId"
                 }
               ],
               "platformOptions": {
@@ -1074,7 +1074,7 @@
                   "accountIds": [
                     0
                   ],
-                  "query": "FROM Metric SELECT average(spark.app.executor.memory.usedOffHeapStorageMemory) WHERE sparkAppExecutorId != 'driver' AND spark.app.executor.memory.usedOffHeapStorageMemory IS NOT NULL TIMESERIES FACET sparkAppExecutorId"
+                  "query": "FROM Metric SELECT average(spark.app.executor.memory.usedOffHeapStorage) WHERE sparkAppExecutorId != 'driver' AND spark.app.executor.memory.usedOffHeapStorage IS NOT NULL TIMESERIES FACET sparkAppExecutorId"
                 }
               ],
               "platformOptions": {


### PR DESCRIPTION
# Description

The executor used on/off heap memory charts are not displaying properly due to incorrect metric names in the dashboard.  This fix corrects the metric names.
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have performed a self-review of my code