### PR TITLE
feat: add support for running integration on driver node of cluster

### DIFF
--- a/cmd/databricks/databricks.go
+++ b/cmd/databricks/databricks.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/newrelic-experimental/newrelic-databricks-integration/internal/databricks"
+	"github.com/newrelic-experimental/newrelic-databricks-integration/internal/spark"
 	"github.com/newrelic/newrelic-labs-sdk/v2/pkg/integration"
 	"github.com/newrelic/newrelic-labs-sdk/v2/pkg/integration/log"
 	"github.com/spf13/viper"
@@ -31,25 +31,16 @@ func main() {
 	)
 	fatalIfErr(err)
 
-	mode := viper.GetString("mode")
-	if mode == "" {
-		mode = "databricks"
+	tags := viper.GetStringMapString("tags")
+
+	if viper.IsSet("databricks") {
+		err = databricks.InitPipelines(ctx, i, tags)
+		fatalIfErr(err)
 	}
 
-	switch mode {
-	case "databricks":
-		err = databricks.InitPipelines(ctx, i)
+	if viper.IsSet("spark") {
+		err = spark.InitPipelines(ctx, i, tags)
 		fatalIfErr(err)
-
-	// @TODO: support any spark context
-	//case "spark":
-	//	err = spark.InitPipelines(i)
-	//	fatalIfErr(err)
-
-	// @TODO: support other cluster providers/modes like yarn/k8s
-
-	default:
-		fatalIfErr(fmt.Errorf("unrecognized mode %s", mode))
 	}
 
 	// Run the integration

--- a/configs/config.template.yml
+++ b/configs/config.template.yml
@@ -11,22 +11,18 @@ pipeline:
 log:
   level: warn
   fileName: trace.log
-
-mode: databricks
-
 databricks:
   workspaceHost: [YOUR_DATABRICKS_WORKSPACE_INSTANCE_NAME]
   accessToken: [YOUR_DATABRICKS_PERSONAL_ACCESS_TOKEN]
   oauthClientId: [YOUR_DATABRICKS_SERVICE_PRINCIPAL_OAUTH_CLIENT_ID]
   oauthClientSecret: [YOUR_DATABRICKS_SERVICE_PRINCIPAL_OAUTH_CLIENT_SECRET]
+  sparkMetrics: true
+  sparkMetricPrefix: spark.
   # RESERVED FOR FUTURE USE
   #accountHost: https://accounts.cloud.databricks.com
-  # RESERVED FOR FUTURE USE
-  #sparkMetrics: true
-
 spark:
-  # RESERVED FOR FUTURE USE
-  #contexts:
-  #- contextUrl1
-  #- contextUrl2
+  webUiUrl: http://localhost:4040
   metricPrefix: spark.
+tags:
+  key1: value
+  key2: value

--- a/init/cluster_init_integration.sh
+++ b/init/cluster_init_integration.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Don't install the integration on executors
+
+if [ "$DB_IS_DRIVER" != "TRUE" ]; then
+  exit
+fi
+
+# Define the version, download dir and target dir
+NEW_RELIC_DATABRICKS_TMP_DIR="/tmp/newrelic-databricks-integration"
+NEW_RELIC_DATABRICKS_TARGET_DIR="/databricks/driver/newrelic"
+NEW_RELIC_DATABRICKS_RELEASE_ARCHIVE="newrelic-databricks-integration_Linux_x86_64.tar.gz"
+
+# Download the newrelic databricks integration release archive, unpack it, and
+# move the binary into place
+mkdir -p $NEW_RELIC_DATABRICKS_TMP_DIR
+curl -o $NEW_RELIC_DATABRICKS_TMP_DIR/$NEW_RELIC_DATABRICKS_RELEASE_ARCHIVE -L https://github.com/newrelic-experimental/newrelic-databricks-integration/releases/latest/download/$NEW_RELIC_DATABRICKS_RELEASE_ARCHIVE
+cd $NEW_RELIC_DATABRICKS_TMP_DIR && tar zvxf $NEW_RELIC_DATABRICKS_RELEASE_ARCHIVE
+mkdir -p $NEW_RELIC_DATABRICKS_TARGET_DIR
+cp $NEW_RELIC_DATABRICKS_TMP_DIR/newrelic-databricks-integration $NEW_RELIC_DATABRICKS_TARGET_DIR
+cd $NEW_RELIC_DATABRICKS_TARGET_DIR && mkdir -p configs
+
+# Create the integration configuration file
+sudo cat <<EOF > $NEW_RELIC_DATABRICKS_TARGET_DIR/configs/config.yml
+apiKey: $NEW_RELIC_API_KEY
+licenseKey: $NEW_RELIC_LICENSE_KEY
+accountId: $NEW_RELIC_ACCOUNT_ID
+region: $NEW_RELIC_REGION
+interval: 30
+runAsService: true
+databricks:
+  workspaceHost: $NEW_RELIC_DATABRICKS_WORKSPACE_HOST
+  accessToken: "$NEW_RELIC_DATABRICKS_ACCESS_TOKEN"
+  oauthClientId: "$NEW_RELIC_DATABRICKS_OAUTH_CLIENT_ID"
+  oauthClientSecret: "$NEW_RELIC_DATABRICKS_OAUTH_CLIENT_SECRET"
+  sparkMetrics: false
+spark:
+  webUiUrl: http://{UI_HOST}:{UI_PORT}
+  metricPrefix: spark.
+tags:
+  databricksClusterId: $DB_CLUSTER_ID
+  databricksClusterName: $DB_CLUSTER_NAME
+EOF
+
+chmod 600 $NEW_RELIC_DATABRICKS_TARGET_DIR/configs/config.yml
+
+# Create integration startup file
+sudo cat <<EOM > $NEW_RELIC_DATABRICKS_TARGET_DIR/start-integration.sh
+#!/bin/bash
+
+TRIES=0
+
+while [ \$TRIES -lt 5 ]; do
+  if [ ! -e /tmp/driver-env.sh ]; then
+    sleep 5
+  fi
+
+  TRIES=\$((TRIES + 1))
+done
+
+if [ ! -e /tmp/driver-env.sh ]; then
+  echo Integration failed to start - missing /tmp/driver-env.sh
+  exit 1
+fi
+
+source /tmp/driver-env.sh
+
+sed -i "s/{UI_HOST}/\$CONF_PUBLIC_DNS/;s/{UI_PORT}/\$CONF_UI_PORT/" \
+  $NEW_RELIC_DATABRICKS_TARGET_DIR/configs/config.yml
+
+$NEW_RELIC_DATABRICKS_TARGET_DIR/newrelic-databricks-integration
+EOM
+
+chmod 500 $NEW_RELIC_DATABRICKS_TARGET_DIR/start-integration.sh
+
+# Create systemd service file
+sudo cat <<EOM > /etc/systemd/system/newrelic-databricks-integration.service
+[Unit]
+Description=New Relic Databricks Integration
+After=network.target
+
+[Service]
+RuntimeDirectory=newrelic-databricks-integration
+WorkingDirectory=$NEW_RELIC_DATABRICKS_TARGET_DIR
+Type=exec
+ExecStart=$NEW_RELIC_DATABRICKS_TARGET_DIR/start-integration.sh
+MemoryLimit=1G
+# MemoryMax is only supported in systemd > 230 and replaces MemoryLimit. Some cloud dists do not have that version
+# MemoryMax=1G
+Restart=always
+RestartSec=30
+StartLimitInterval=200
+StartLimitBurst=5
+PIDFile=/run/newrelic-databricks-integration/newrelic-databricks-integration.pid
+
+[Install]
+WantedBy=multi-user.target
+EOM
+
+# Enable and run the service
+sudo systemctl daemon-reload
+sudo systemctl enable newrelic-databricks-integration.service
+sudo systemctl start newrelic-databricks-integration

--- a/internal/databricks/databricks.go
+++ b/internal/databricks/databricks.go
@@ -3,6 +3,7 @@ package databricks
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	databricksSdk "github.com/databricks/databricks-sdk-go"
@@ -18,6 +19,7 @@ import (
 func InitPipelines(
 	ctx context.Context,
 	i *integration.LabsIntegration,
+	tags map[string]string,
 ) error {
 	// Databricks config
 	databricksConfig := &databricksSdk.Config{}
@@ -96,14 +98,17 @@ func InitPipelines(
 					c.ClusterName,
 					sparkContextUiPath,
 				)
-				err = spark.InitPipelines(
+
+				newTags := maps.Clone(tags)
+				newTags["clusterProvider"] = "databricks"
+				newTags["databricksClusterId"] = c.ClusterId
+				newTags["databricksClusterName"] = c.ClusterName
+
+				err = spark.InitPipelinesWithClient(
 					i,
 					databricksSparkApiClient,
-					map[string] string {
-						"clusterProvider": "databricks",
-						"databricksClusterId": c.ClusterId,
-						"databricksClusterName": c.ClusterName,
-					},
+					viper.GetString("databricks.sparkMetricPrefix"),
+					newTags,
 				)
 				if err != nil {
 					return err


### PR DESCRIPTION
# Description

* Add support for running the integration on the driver node of the cluster via a cluster-scoped init script
* Add support to run against non-Databricks spark deployments
* Add support for tags in the config

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
