### PR TITLE
fix(init-script): add databricks* attributes to Log events using record_modifier in fluentbit.conf

### DIFF
--- a/init/cluster_init_integration.sh
+++ b/init/cluster_init_integration.sh
@@ -32,8 +32,8 @@ custom_attributes:
   databricksWorkspaceHost: $NEW_RELIC_DATABRICKS_WORKSPACE_HOST
   databricksClusterId: $DB_CLUSTER_ID
   databricksClusterName: $DB_CLUSTER_NAME
-  databricksIsDriverNode: $DB_IS_DRIVER
-  databricksIsJobCluster: $DB_IS_JOB_CLUSTER
+  databricksIsDriverNode: ${DB_IS_DRIVER,,}
+  databricksIsJobCluster: ${DB_IS_JOB_CLUSTER,,}
 EOM
 
   if [ "$NEW_RELIC_INFRASTRUCTURE_LOGS_ENABLED" = "true" ]; then
@@ -105,6 +105,15 @@ EOM
     Buffer_Max_Size 512k
     Mem_Buf_Limit 16384k
     Skip_Long_Lines On
+
+[FILTER]
+    Name record_modifier
+    Match *
+    Record databricksWorkspaceHost $NEW_RELIC_DATABRICKS_WORKSPACE_HOST
+    Record databricksClusterId $DB_CLUSTER_ID
+    Record databricksClusterName $DB_CLUSTER_NAME
+    Record databricksIsDriverNode ${DB_IS_DRIVER,,}
+    Record databricksIsJobCluster ${DB_IS_JOB_CLUSTER,,}
 
 [FILTER]
     Name record_modifier
@@ -217,6 +226,15 @@ EOM
     Buffer_Max_Size 128k
     Mem_Buf_Limit 16384k
     Skip_Long_Lines On
+
+[FILTER]
+    Name record_modifier
+    Match *
+    Record databricksWorkspaceHost $NEW_RELIC_DATABRICKS_WORKSPACE_HOST
+    Record databricksClusterId $DB_CLUSTER_ID
+    Record databricksClusterName $DB_CLUSTER_NAME
+    Record databricksIsDriverNode ${DB_IS_DRIVER,,}
+    Record databricksIsJobCluster ${DB_IS_JOB_CLUSTER,,}
 
 [FILTER]
     Name record_modifier


### PR DESCRIPTION
# Description

Add new `record_modifier` `[FILTER]`s to the `fluentbit.conf` generated by `cluster_init_script.sh` to consistently add the `databricks*` attributes to all `Log` events.

Also had to update the use of `$DB_IS_DRIVER` and `$DB_IS_JOB_CLUSTER` in the `custom_attributes` section of the `newrelic-infra.yml` to lower-case the values so that they are consistently lower-cased to match the lower-cased values in the new filters.

This is needed because the infrastructure agent does not consistently add attributes in the `custom_attributes` section of the `newrelic-infra.yml` to `Log` events when it is configured to forward logs.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Removed `custom_attributes` from init script and then checked all generated `Log` messages manually to confirm attributes are added via the `record_modifier` filters

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
